### PR TITLE
upgrade to matrix and remove python 2 support

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.srfplaytv" name="SRF Play TV" version="1.6.0" provider-name="Alexander Seiler">
+<addon id="plugin.video.srfplaytv" name="SRF Play TV" version="1.7.0" provider-name="Alexander Seiler">
   <requires>
-    <import addon="xbmc.python" version="2.25.0"/>
-    <import addon="script.module.srgssr" version="1.7.0"/>
-    <import addon="script.module.kodi-six" version="0.0.2"/>
+    <import addon="xbmc.python" version="3.0.0"/>
+    <import addon="script.module.srgssr" version="1.8.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>video</provides>

--- a/resources/lib/srfplaytv.py
+++ b/resources/lib/srfplaytv.py
@@ -22,14 +22,12 @@
 import sys
 import traceback
 
-try:  # Python 3
-    from urllib.parse import unquote_plus
-    from urllib.parse import parse_qsl
-except ImportError:  # Python 2
-    from urlparse import parse_qsl
-    from urllib import unquote_plus
+from urllib.parse import unquote_plus
+from urllib.parse import parse_qsl
 
-from kodi_six import xbmc, xbmcaddon, xbmcplugin
+import xbmc
+import xbmcaddon
+import xbmcplugin
 import srgssr
 
 ADDON_ID = 'plugin.video.srfplaytv'


### PR DESCRIPTION
Some URLs do not work anymore. It seems like the SRFPlay website has changed quite a bit since the last release. For example, the recommendations are gone and the front page is now divided into media sections with different ids. But for a start we could just release a new version for matrix and fix these issues later.